### PR TITLE
Modification to error handling in the raft

### DIFF
--- a/src/raft_client.c
+++ b/src/raft_client.c
@@ -1754,19 +1754,21 @@ raft_client_reply_try_complete(struct raft_client_instance *rci,
     raft_client_sub_app_put(rci, sa, __func__, __LINE__);
 }
 
-/*
-raft_client_error_handler processes errors received from the 
-Raft server. If the error needs to be propagated to the Pumice layer, 
-it should be stored in rcrm_app_error. The function should return 
-true if the request processing should continue.
-*/
-bool raft_client_error_handler(struct raft_client_rpc_msg *rcrm) {
-    switch (rcrm->rcrm_sys_error) {
+/**
+ * raft_client_error_handler - Processes errors received from the
+ * Raft server. If the error needs to be propagated to the Pumice layer,
+ * it should be stored in rcrm_app_error. The function should return
+ * true if the request processing should continue to the Pumice layer.
+ */
+bool
+raft_client_sys_app_error_handler(struct raft_client_rpc_msg *rcrm)
+{
+    switch (rcrm->rcrm_sys_error)
+    {
         default:
             rcrm->rcrm_app_error = rcrm->rcrm_sys_error;
-            return true;
+            break;
     }
-
     return true;
 }
 
@@ -1793,9 +1795,8 @@ raft_client_recv_handler_process_reply(
     else if (rcrm->rcrm_sys_error)
     {
         DBG_RAFT_CLIENT_RPC_SOCK(LL_NOTIFY, rcrm, from, "sys-err=%s",
-                                strerror(-rcrm->rcrm_sys_error));
-        bool cpflag = raft_client_error_handler(rcrm);
-        if (!cpflag)
+                                 strerror(-rcrm->rcrm_sys_error));
+        if(!raft_client_sys_app_error_handler(rcrm))
             return;
     }
 

--- a/src/raft_client.c
+++ b/src/raft_client.c
@@ -1800,7 +1800,7 @@ raft_client_recv_handler_process_reply(
     {
         DBG_RAFT_CLIENT_RPC_SOCK(LL_NOTIFY, rcrm, from, "sys-err=%s",
                                  strerror(-rcrm->rcrm_sys_error));
-        raft_client_sys_app_error_handler(rcrm)
+        raft_client_sys_app_error_handler(rcrm);
     }
 
     niova_realtime_coarse_clock(&rci->rci_last_request_ackd);

--- a/src/raft_client.c
+++ b/src/raft_client.c
@@ -1756,11 +1756,10 @@ raft_client_reply_try_complete(struct raft_client_instance *rci,
 
 /**
  * raft_client_error_handler - Processes errors received from the
- * Raft server. If the error needs to be propagated to the Pumice layer,
- * it should be stored in rcrm_app_error. The function should return
- * true if the request processing should continue to the Pumice layer.
+ * raft server. If the error needs to be propagated to the Pumice layer,
+ * it should be stored in rcrm_app_error.
  */
-bool
+void
 raft_client_sys_app_error_handler(struct raft_client_rpc_msg *rcrm)
 {
     switch (rcrm->rcrm_sys_error)
@@ -1775,7 +1774,6 @@ raft_client_sys_app_error_handler(struct raft_client_rpc_msg *rcrm)
             rcrm->rcrm_app_error = rcrm->rcrm_sys_error;
             break;
     }
-    return true;
 }
 
 /**
@@ -1802,8 +1800,7 @@ raft_client_recv_handler_process_reply(
     {
         DBG_RAFT_CLIENT_RPC_SOCK(LL_NOTIFY, rcrm, from, "sys-err=%s",
                                  strerror(-rcrm->rcrm_sys_error));
-        if(!raft_client_sys_app_error_handler(rcrm))
-            return;
+        raft_client_sys_app_error_handler(rcrm)
     }
 
     niova_realtime_coarse_clock(&rci->rci_last_request_ackd);

--- a/src/raft_client.c
+++ b/src/raft_client.c
@@ -1765,6 +1765,12 @@ raft_client_sys_app_error_handler(struct raft_client_rpc_msg *rcrm)
 {
     switch (rcrm->rcrm_sys_error)
     {
+        case -ENOENT:
+        case -ENOSYS:
+        case -EAGAIN:
+        case -EBUSY:
+            rcrm->rcrm_app_error = -EAGAIN;
+            break;
         default:
             rcrm->rcrm_app_error = rcrm->rcrm_sys_error;
             break;


### PR DESCRIPTION
This PR contains following changes:
1. Creation of raft client error handler
2. Modifications to the error handling in the raft server
 


**Creation of raft client error handler**
The handler processes the rcrm_sys_error and decides the course of following actions:
1. Decicde the error to be forwarded to the pumice layer or the layer above raft through rcrm_app_error
2. If the request should be retried or not.
3. Any other error appropriate action