### PR TITLE
Fix for the timeout issue during make check step in the CI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,7 +70,7 @@ noinst_PROGRAMS += test/raft-net-test
 test_raft_net_test_SOURCES =   \
 	$(RAFT_NET_CORE_SOURCES) test/raft-net-test.c
 test_raft_net_test_LDADD = $(NIOVA_LIBS) $(NIOVA_BT_LIB)
-test_raft_net_test_CFLAGS = $(AM_CFLAGS)
+test_raft_net_test_CFLAGS = $(AM_CFLAGS) -DUNIT_TEST
 TESTS += test/raft-net-test
 
 autofmt:

--- a/src/include/raft_net.h
+++ b/src/include/raft_net.h
@@ -287,7 +287,17 @@ raft_client_rpc_msg_size_is_valid(enum raft_instance_store_type store_type,
         raft_net_max_rpc_size(store_type) ? true : false;
 }
 
+#ifdef UNIT_TEST
+/* FIXME: Reduced limit for unit tests due to ASAN performance issues.
+ * With ASAN enabled, tests with RAFT_NET_WR_SUPP_MAX = (1024*1024)+1024 take
+ * extremely long to complete (hours) due to excessive munmap/mmap calls in
+ * ASAN. See: https://github.com/00pauln00/niova-raft/issues/20
+ * TODO: Investigate and understand why ASAN takes so long to run.
+ */
+#define RAFT_NET_WR_SUPP_MAX 1024
+#else
 #define RAFT_NET_WR_SUPP_MAX (1024*1024)+1024 // arbitrary limit..
+#endif
 
 
 enum raft_net_wr_supp_op


### PR DESCRIPTION
make check takes forever to complete for 1M keys with asan enabled, hence a temp fix to run with less keys until we figure out the actual reason (Fixes #20)

About 2 minutes for 100k. 

```
Progress: 10000/1049600 items added (0.95%) - Elapsed: 1 seconds
Progress: 20000/1049600 items added (1.91%) - Elapsed: 7 seconds
Progress: 30000/1049600 items added (2.86%) - Elapsed: 16 seconds
Progress: 40000/1049600 items added (3.81%) - Elapsed: 29 seconds
Progress: 50000/1049600 items added (4.76%) - Elapsed: 45 seconds
Progress: 60000/1049600 items added (5.72%) - Elapsed: 63 seconds
Progress: 70000/1049600 items added (6.67%) - Elapsed: 85 seconds
Progress: 80000/1049600 items added (7.62%) - Elapsed: 111 seconds
```